### PR TITLE
formatting and remove deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Hello!
 
-This is a personal website project of mine, dedicated to my general online presence. 
+This is a personal website project of mine, dedicated to my general online presence.
 
-<img src="images/marisa.png" height="200px">
+<center> <!--deprecated but it's the only way to center images in markdown files in github-->
+<img src="images/marisa.png" height="200px" alt="marisa">
+</center>
 
 At the moment it's just a static home page, but I intend on adding blog features, embedding my Twitch streams into it, hosting my webcomic and art on it, and so on.
 
 Deployed to [maddy.lol](https://maddy.lol/) via GitHub Pages!
-

--- a/css/framestyle.css
+++ b/css/framestyle.css
@@ -1,39 +1,44 @@
 html {
-    background-color: rgb(209, 139, 211);
-    color: black;
-    margin: 0;
-    padding: 0;
-    cursor: url('../cursor/diamondsword.cur'), pointer;
-    overflow-x: hidden;
-    flex-direction: column;
-  }
+  background-color: rgb(209, 139, 211);
+  color: black;
+  margin: 0;
+  padding: 0;
+  cursor: url('../cursor/diamondsword.cur'), pointer;
+  overflow-x: hidden;
+  flex-direction: column;
+}
 
-  #marisa {
-    height: 100px;
-  }
+#marisa {
+  height: 100px;
+}
 
-    /* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
+/* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
 @media screen and (max-width: 480px) {
-    .navbar {padding-top: 5px;   height: 100%;width: 75%;}
-    .navbar a {font-size: 12px;}
+  .navbar {
+    padding-top: 5px;
+    height: 100%;
+    width: 75%;
   }
-  
-  body {
-    background-color: rgb(152, 109, 174);
-    border:outset;
-    border-color:rgb(139, 87, 187);
-    height: 320px;
-    width: 450px;
-    color:floralwhite
+  .navbar a {
+    font-size: 12px;
   }
+}
 
-  h1
-  {
-    text-align: center;
-  }
+body {
+  background-color: rgb(152, 109, 174);
+  border: outset;
+  border-color: rgb(139, 87, 187);
+  height: 320px;
+  width: 450px;
+  color: floralwhite;
+}
 
-  p{
-    text-align: center;
-    padding: 25px;
-    font-size: 20px;
-  }
+h1 {
+  text-align: center;
+}
+
+p {
+  text-align: center;
+  padding: 25px;
+  font-size: 20px;
+}

--- a/css/sidebarstyle.css
+++ b/css/sidebarstyle.css
@@ -1,47 +1,51 @@
 html {
-    background-color: rgb(159, 88, 161);
-    color: black;
-    margin: 0;
-    padding: 0;
-    cursor: url('../cursor/diamondsword.cur'), auto;
-    overflow-x: hidden;
-  }
+  background-color: rgb(159, 88, 161);
+  color: black;
+  margin: 0;
+  padding: 0;
+  cursor: url('../cursor/diamondsword.cur'), auto;
+  overflow-x: hidden;
+}
 
-  #marisa {
-    height: 100px;
-  }
+#marisa {
+  height: 100px;
+}
 
-    /* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
+/* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
 @media screen and (max-width: 480px) {
-    .navbar {padding-top: 5px;   height: 100%;width: 75%;}
-    .navbar a {font-size: 12px;}
+  .navbar {
+    padding-top: 5px;
+    height: 100%;
+    width: 75%;
   }
-
-  p {
-    font-family: Arial, Helvetica, sans-serif;
-    text-decoration:underline;
-    margin: 40px;
-    font-size: 25px;
-    padding: 0;
-    color:floralwhite;
-    text-align: center;
+  .navbar a {
+    font-size: 12px;
   }
-
-.nav
-{
-    list-style-type: none;
-    margin:25px;
-    font-size: 25px;
-    padding: 0;
-    text-align: center;
 }
 
-a
-{
-    color:floralwhite
+p {
+  font-family: Arial, Helvetica, sans-serif;
+  /* it's bad practice to underline things that aren't links, especially when they're the same color as links too */
+  /* text-decoration: underline; */
+  margin: 40px;
+  font-size: 25px;
+  padding: 0;
+  color: floralwhite;
+  text-align: center;
 }
 
-a:hover
-{
-    color:rgb(229, 191, 226)
+.nav {
+  list-style-type: none;
+  margin: 25px;
+  font-size: 25px;
+  padding: 0;
+  text-align: center;
+}
+
+a {
+  color: floralwhite;
+}
+
+a:hover {
+  color: rgb(229, 191, 226);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,36 +2,105 @@
    HTML content. To learn how to do something, just try searching Google for questions like
    "how to change link color." */
 
+html, body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
 html {
-  background-color: rgb(235, 146, 215);
+  background-color: rgb(209, 139, 211); /*rgb(235, 146, 215)*/
   color: black;
   margin: 0;
   padding: 0;
-  cursor: url('/cursor/diamondsword.cur'), auto
+  cursor: url('/cursor/diamondsword.cur'), auto;
+}
+
+#leftside {
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+  height: 100%;
+  width: 275px;
+  background-color: rgb(159, 88, 161);
+  font-family: Arial, Helvetica, sans-serif;
+  color: floralwhite;
+  list-style-type: none;
+  font-size: 25px;
+  & > img {
+    margin: 40px;
+    padding: 0;
+  }
+  & > li, & > p {
+    margin: 12.5px;
+  }
+}
+
+section {
+  text-align: center;
+  margin: 8px;
+  background-color: rgb(152, 109, 174);
+  border: outset;
+  border-color: rgb(139, 87, 187);
+  overflow-y: auto;
+  height: 320px;
+  width: 450px;
+  color: floralwhite;
+  
+  & > h1 {
+    margin: 22.5px;
+    font-size: 2em;
+  }
+  & > p {
+    margin: 0;
+    padding: 25px;
+    font-size: 20px;
+  }
 }
 
 #header {
   margin-bottom: 5px;
-  font-family: 'Times New Roman'
+  font-family: 'Times New Roman';
 }
 
 body {
-  padding: 20px;
+  /* padding: 20px; */
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
+  flex-direction: row;
+  /* align-items: center; */
+  /* text-align: center; */
   overflow-x: hidden;
-  float: center;
+  /* float: center; */
 }
 
 #marisa {
   height: 100px;
+  width: 100px;
   padding: 30px;
 }
 
-  /* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
+/* Danger Maddy! This is how you're shrinking the navbar for mobile devices. */
 @media screen and (max-width: 480px) {
-  .leftside {padding-top: 5px;   height: 100%;width: 75%;}
-  .leftside a {font-size: 12px;}
+  .leftside {
+    padding-top: 5px;
+    height: 100%;
+    width: 75%;
+  }
+  .leftside a {
+    font-size: 12px;
+  }
+}
+
+a {
+  color: floralwhite;
+}
+
+a:hover {
+  color: rgb(229, 191, 226);
 }

--- a/frame/about.html
+++ b/frame/about.html
@@ -1,21 +1,16 @@
 <!DOCTYPE html>
+<html>
 <head>
-<meta charset="UTF-8">
-<title>
-  Maddy's Corner
-    </title>
-
-<link href="../css/framestyle.css" rel="stylesheet" type="text/css" media="all">
-
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<script type="text/javascript" src="../js/main.js"></script>
+  <meta charset="UTF-8">
+  <title>Maddy's Corner</title>
+  <link href="/css/style.css" rel="stylesheet" type="text/css" media="all">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--<script type="text/javascript" src="../js/main.js"></script>-->
 </head>
-
 <body>
-
-<h1>Hello!</h1>
-<p> My name is Maddy, and I'm an artist in her mid 20's! More info to come later, including socials.
-</p>
-
+  <section>
+    <h1>Hello!</h1>
+    <p>My name is Maddy, and I'm an artist in her mid 20's! More info to come later, including socials.</p>
+  </section>
 </body>
+</html>

--- a/frame/blog.html
+++ b/frame/blog.html
@@ -1,22 +1,19 @@
 <!DOCTYPE html>
+<html>
 <head>
-<meta charset="UTF-8">
-<title>
-  Maddy's Corner
-    </title>
-
-<link href="../css/framestyle.css" rel="stylesheet" type="text/css" media="all">
-
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<script type="text/javascript" src="../js/main.js"></script>
+  <meta charset="UTF-8">
+  <title>Maddy's Corner</title>
+  <link href="/css/style.css" rel="stylesheet" type="text/css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--<script type="text/javascript" src="../js/main.js"></script>-->
 </head>
-
 <body>
-
-<h1>Hello!</h1>
-<p>"no one cares about your blogposting dude" - 
-  you, probably
-</p>
-
+  <section>
+    <h1>Hello!</h1>
+    <p>
+      "no one cares about your blogposting dude"
+      - you, probably
+    </p>
+  </section>
 </body>
+</html>

--- a/frame/frame.html
+++ b/frame/frame.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <head>
 <meta charset="UTF-8">
-<title>
-  Maddy's Corner
-    </title>
+<title>Maddy's Corner</title>
 
 <link href="../css/framestyle.css" rel="stylesheet" type="text/css" media="all">
 
@@ -15,7 +13,8 @@
 <body>
 
 <h1>Hello!</h1>
-<p>This the homepage that I created for my online endeavors!
+<p>
+  This the homepage that I created for my online endeavors!
   Admittedly I don't intend on putting a whole lot on this site at the moment,
   but I do wish to host my comic here once it starts up! There's also a 
   blog here if you care about my thoughts on things, and the about me section 

--- a/frame/soulsign.html
+++ b/frame/soulsign.html
@@ -1,24 +1,22 @@
 <!DOCTYPE html>
+<html>
 <head>
-<meta charset="UTF-8">
-<title>
-  Maddy's Corner
-    </title>
-
-<link href="../css/framestyle.css" rel="stylesheet" type="text/css" media="all">
-
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<script type="text/javascript" src="../js/main.js"></script>
+  <meta charset="UTF-8">
+  <title>Maddy's Corner</title>
+  <link rel="stylesheet" type="text/css" href="/css/style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/images/marisa.jpg">
+  <!--<script type="text/javascript" src="../js/main.js"></script>-->
 </head>
-
 <body>
-
-<h1>Hello!</h1>
-<p>This is where I intend on hosting my webcomic Soulsign once I start posting it. 
-  It's about brothers Theo and Paul alongside their friend Riley uncovering the secrets 
-  of their local town. I'll talk more about it soon when I've got it in a state that I'm 
-  comfortable sharing with the world!
-</p>
-
+  <section>
+    <h1>Hello!</h1>
+    <p>
+      This is where I intend on hosting my webcomic Soulsign once I start posting it. 
+      It's about brothers Theo and Paul alongside their friend Riley uncovering the secrets 
+      of their local town. I'll talk more about it soon when I've got it in a state that I'm 
+      comfortable sharing with the world!
+    </p>
+  </section>
 </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,16 +6,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
+  
   <!-- Page Title -->
   <title>Maddy's Corner</title>
-
+  
   <!-- Search Engine Optimization  -->
   <meta name="keywords" content="maddblamma, redskywarn, soulsign"> <!-- TODO: configure these as you please -->
   <meta name="description" content=""> <!-- TODO: add your description here :) -->
   
   <!-- Discord Meta Tags -->
   <!-- note from fangs: thanks spax lol -->
+  <!-- note from spax: :imstuff: -->
   <meta property="og:url" content="https://maddy.lol">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Maddy's Corner">
@@ -31,23 +32,47 @@
   <meta name="twitter:image" content="https://maddy.lol/images/marisa.png"> <!-- TODO: add actual image content lol -->
   
   <!-- Styling -->
-  <link rel="icon" type="image/x-icon" href="maddy/put/favicon/here"> <!-- TODO: add favicon -->
-  <link rel="stylesheet" type="text/css" href="css/style.css">
-
+  <link rel="icon" type="image/x-icon" href="/images/marisa.jpg"> <!-- TODO: add real favicon -->
+  <link rel="stylesheet" type="text/css" href="/css/style.css">
 </head>
-
-<frameset cols="275px, *" frameborder="0">
-<frame name="leftside" src="/sidebar/sidebar.html"></frame>
-<frame name="center" src="/frame/frame.html"></frame>
-</frameset>
-
 <body>
-
-<!--
-Maddy. it's actually better to load JavaScript files right before the body closes.
-It improves loading times because the browser can load the whole website before loading your JS. -fangs
--->
-<script src="js/main.js"></script>
-
+  <!-- frameset and frame tags are deprecated. ported to more modern tags below
+  <frameset cols="275px, *" frameborder="0">
+  <frame name="leftside" src="/sidebar/sidebar.html"></frame>
+  <frame name="center" src="/frame/frame.html"></frame>
+  </frameset>
+  -->
+  <menu id="leftside">
+    <img id="marisa" src="../images/marisa.jpg" alt="why am i so obsessed with these stupid fumos" onclick="playAudio('../sound/Squee.mp3')">
+    <p>MADDBLAMMA!</p>
+    <li class="nav">
+      <a href="../index.html" target="center">HOME</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/soulsign.html" target="center">SOULSIGN</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/blog.html" target="center">BLOG</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/about.html" target="center">ABOUT</a>
+    </li>
+  </menu>
+  <section>
+    <h1>Hello!</h1>
+    <p>
+      This the homepage that I created for my online endeavors!
+      Admittedly I don't intend on putting a whole lot on this site at the moment,
+      but I do wish to host my comic here once it starts up! There's also a 
+      blog here if you care about my thoughts on things, and the about me section 
+      talks more about who I am in specific! Thank you for visiting!
+    </p>
+  </section>
+  <!--
+  Maddy. it's actually better to load JavaScript files right before the body closes.
+  It improves loading times because the browser can load the whole website before loading your JS. -fangs
+  plus! it ensures all of your elements are created already. -spax
+  -->
+  <!--<script src="js/main.js"></script>-->
 </body>
-</html>>
+</html>

--- a/index.html
+++ b/index.html
@@ -46,16 +46,16 @@
     <img id="marisa" src="../images/marisa.jpg" alt="why am i so obsessed with these stupid fumos" onclick="playAudio('../sound/Squee.mp3')">
     <p>MADDBLAMMA!</p>
     <li class="nav">
-      <a href="../index.html" target="center">HOME</a>
+      <a href="../index.html">HOME</a>
     </li>
     <li class="nav">
-      <a href="../frame/soulsign.html" target="center">SOULSIGN</a>
+      <a href="../frame/soulsign.html">SOULSIGN</a>
     </li>
     <li class="nav">
-      <a href="../frame/blog.html" target="center">BLOG</a>
+      <a href="../frame/blog.html">BLOG</a>
     </li>
     <li class="nav">
-      <a href="../frame/about.html" target="center">ABOUT</a>
+      <a href="../frame/about.html">ABOUT</a>
     </li>
   </menu>
   <section>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,11 @@
 // Placeholder file for main JavaScript
 function playAudio(url) {
-    new Audio(url).play();
-  }
+  new Audio(url).play();
+}
 
-  init();
+init();
+
+//placeholder so it doesn't complain that init doesn't exist
+function init() {
+  console.log("running!");
+}

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -1,42 +1,29 @@
 <!DOCTYPE html>
+<html>
 <head>
 <meta charset="UTF-8">
-<title>
-  Maddy's Corner
-    </title>
-
-<link href="../css/sidebarstyle.css" rel="stylesheet" type="text/css" media="all">
-
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<script type="text/javascript" src="../js/main.js"></script>
+  <title>Maddy's Corner</title>
+  <link rel="stylesheet" type="text/css" href="/css/style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/images/marisa.jpg">
+  <!--<script type="text/javascript" src="../js/main.js"></script>-->
 </head>
-
 <body>
-<p>
   <img id="marisa" src="../images/marisa.jpg" alt="why am i so obsessed with these stupid fumos" onclick="playAudio('../sound/Squee.mp3')">
-</p>
-<div>
-<p>
-  MADDBLAMMA!
-</p>
-
-<li class="nav">
-  <a href="../frame/frame.html" target="center">HOME</a>
-</li>
-
-<li class="nav">
-  <a href="../frame/soulsign.html" target="center">SOULSIGN</a>
-</li>
-
-<li class="nav">
-  <a href="../frame/blog.html" target="center">BLOG</a>
-</li>
-
-<li class="nav">
-    <a href="../frame/about.html" target="center">ABOUT</a>
-  </li>
-
-</div>
-
+  <div>
+    <p>MADDBLAMMA!</p>
+    <li class="nav">
+      <a href="../frame/frame.html" target="center">HOME</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/soulsign.html" target="center">SOULSIGN</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/blog.html" target="center">BLOG</a>
+    </li>
+    <li class="nav">
+      <a href="../frame/about.html" target="center">ABOUT</a>
+    </li>
+  </div>
 </body>
+</html>


### PR DESCRIPTION
saw catfxngs' activity on here and decided to help out too

major changes:
- removed `<frameset>` and `<frame>`s in favor of natively displaying the contents of the linked pages in the html itself
  - used `<menu>` tag for the leftside thingy, and `<section>` for the box thingy
  - should look pretty close to how it looked originally, with the exception of font families. the original page was a bit inconsistent with them so I'll leave that up to you
- removed blank lines
- added placeholder favicon (it's just marisa)
- cleaned up whitespace for the most part
- centered the marisa image in the readme using black magic (the deprecated `<center>` tag)
- removed underline from the p tags, since it's bad practice
- commented out the unused javascript. you can uncomment it when you put actual stuff in it but since it isn't doing anything yet it's best to leave it out of the page for now.

feel free to revert any changes. enjoy!